### PR TITLE
Annotations

### DIFF
--- a/ember_ontology.owl
+++ b/ember_ontology.owl
@@ -27,6 +27,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">has_action</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -37,6 +39,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">has_file_feature</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -47,6 +51,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">has_section</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -57,6 +63,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">has_section_feature</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -67,6 +75,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">has_section_flag</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -88,6 +98,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">exports_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -98,6 +110,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">imports_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -108,6 +122,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">mz_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -118,6 +134,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">paths_strings_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -128,6 +146,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">registry_strings_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -138,6 +158,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">section_entropy</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -148,6 +170,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">section_name</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -158,6 +182,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">symbols_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -168,6 +194,8 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">urls_strings_count</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -187,6 +215,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AcceptSocketConnection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AcceptSocketConnection</rdfs:label>
     </owl:Class>
     
 
@@ -195,13 +225,18 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AccessManagement</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action">
+        <rdfs:comment xml:lang="en">Subclasses of Action represent types of actions that can be performed by a PE file when it is executed. Leaf subclasses (i.e., those without any named subclasses of their own except themselves, e.g., CreateProcess) are taken from the MAEC Malware actions vocabulary. Direct subclasses of Action (e.g., ProcessHandling) categorize leaf actions to aid generalization.</rdfs:comment>
+        <rdfs:label xml:lang="en">Action</rdfs:label>
+    </owl:Class>
     
 
 
@@ -209,6 +244,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AddNetworkShare">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ResourceSharing"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AddNetworkShare</rdfs:label>
     </owl:Class>
     
 
@@ -217,6 +254,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AddScheduledTask">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AddScheduledTask</rdfs:label>
     </owl:Class>
     
 
@@ -225,6 +264,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AddUser">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AddUser</rdfs:label>
     </owl:Class>
     
 
@@ -233,6 +274,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AddWindowsHook">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AddWindowsHook</rdfs:label>
     </owl:Class>
     
 
@@ -241,6 +284,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AllocateProcessVirtualMemory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AllocateProcessVirtualMemory</rdfs:label>
     </owl:Class>
     
 
@@ -249,6 +294,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AntiDebugging">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">AntiDebugging</rdfs:label>
     </owl:Class>
     
 
@@ -257,6 +304,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#BindAddressToSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">BindAddressToSocket</rdfs:label>
     </owl:Class>
     
 
@@ -265,6 +314,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CLR">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CLR</rdfs:label>
     </owl:Class>
     
 
@@ -273,6 +324,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ChangePassword">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ChangePassword</rdfs:label>
     </owl:Class>
     
 
@@ -281,6 +334,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CheckForKernelDebugger">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AntiDebugging"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CheckForKernelDebugger</rdfs:label>
     </owl:Class>
     
 
@@ -289,6 +344,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CheckForRemoteDebugger">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AntiDebugging"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CheckForRemoteDebugger</rdfs:label>
     </owl:Class>
     
 
@@ -297,6 +354,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CloseFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CloseFile</rdfs:label>
     </owl:Class>
     
 
@@ -305,6 +364,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CloseRegistryKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CloseRegistryKey</rdfs:label>
     </owl:Class>
     
 
@@ -313,6 +374,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CloseSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CloseSocket</rdfs:label>
     </owl:Class>
     
 
@@ -321,6 +384,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CodeSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
+        <rdfs:comment xml:lang="en">CodeSection instances represent PE file sections containing program code.</rdfs:comment>
+        <rdfs:label xml:lang="en">CodeSection</rdfs:label>
     </owl:Class>
     
 
@@ -329,6 +394,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ConnectToFtpServer">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ConnectToFtpServer</rdfs:label>
     </owl:Class>
     
 
@@ -337,6 +404,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ConnectToNamedPipe">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#InterProcessCommunication"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ConnectToNamedPipe</rdfs:label>
     </owl:Class>
     
 
@@ -345,6 +414,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ConnectToSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ConnectToSocket</rdfs:label>
     </owl:Class>
     
 
@@ -353,6 +424,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ConnectToUrl">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ConnectToUrl</rdfs:label>
     </owl:Class>
     
 
@@ -361,6 +434,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CopyFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CopyFile</rdfs:label>
     </owl:Class>
     
 
@@ -369,6 +444,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateCriticalSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateCriticalSection</rdfs:label>
     </owl:Class>
     
 
@@ -377,6 +454,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateDialogBox">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateDialogBox</rdfs:label>
     </owl:Class>
     
 
@@ -385,6 +464,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DirectoryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -393,6 +474,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateEvent">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateEvent</rdfs:label>
     </owl:Class>
     
 
@@ -401,6 +484,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateFile</rdfs:label>
     </owl:Class>
     
 
@@ -409,6 +494,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateFileMapping">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateFileMapping</rdfs:label>
     </owl:Class>
     
 
@@ -417,6 +504,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateFileSymbolicLink">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateFileSymbolicLink</rdfs:label>
     </owl:Class>
     
 
@@ -425,6 +514,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateMailslot">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#InterProcessCommunication"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateMailslot</rdfs:label>
     </owl:Class>
     
 
@@ -433,6 +524,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateMutex">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateMutex</rdfs:label>
     </owl:Class>
     
 
@@ -441,6 +534,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateNamedPipe">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#InterProcessCommunication"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateNamedPipe</rdfs:label>
     </owl:Class>
     
 
@@ -449,6 +544,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateProcess</rdfs:label>
     </owl:Class>
     
 
@@ -457,6 +554,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateProcessAsUser">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateProcessAsUser</rdfs:label>
     </owl:Class>
     
 
@@ -465,6 +564,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateRegistryKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateRegistryKey</rdfs:label>
     </owl:Class>
     
 
@@ -473,6 +574,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateRegistryKeyValue">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateRegistryKeyValue</rdfs:label>
     </owl:Class>
     
 
@@ -481,6 +584,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateRemoteThreadInProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateRemoteThreadInProcess</rdfs:label>
     </owl:Class>
     
 
@@ -489,6 +594,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateSemaphore">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateSemaphore</rdfs:label>
     </owl:Class>
     
 
@@ -497,6 +604,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateService">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateService</rdfs:label>
     </owl:Class>
     
 
@@ -505,6 +614,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateSocket</rdfs:label>
     </owl:Class>
     
 
@@ -513,6 +624,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateThread">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateThread</rdfs:label>
     </owl:Class>
     
 
@@ -521,6 +634,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CreateWindow">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">CreateWindow</rdfs:label>
     </owl:Class>
     
 
@@ -529,6 +644,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Cryptography</rdfs:label>
     </owl:Class>
     
 
@@ -537,6 +654,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Debug">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Debug</rdfs:label>
     </owl:Class>
     
 
@@ -545,6 +664,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Decrypt">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Decrypt</rdfs:label>
     </owl:Class>
     
 
@@ -553,6 +674,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteCriticalSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteCriticalSection</rdfs:label>
     </owl:Class>
     
 
@@ -561,6 +684,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DirectoryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -569,6 +694,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteFile</rdfs:label>
     </owl:Class>
     
 
@@ -577,6 +704,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteNetworkShare">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ResourceSharing"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteNetworkShare</rdfs:label>
     </owl:Class>
     
 
@@ -585,6 +714,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteRegistryKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteRegistryKey</rdfs:label>
     </owl:Class>
     
 
@@ -593,6 +724,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteRegistryKeyValue">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteRegistryKeyValue</rdfs:label>
     </owl:Class>
     
 
@@ -601,6 +734,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteService">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteService</rdfs:label>
     </owl:Class>
     
 
@@ -609,6 +744,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DeleteUser">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DeleteUser</rdfs:label>
     </owl:Class>
     
 
@@ -617,6 +754,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DirectoryHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DirectoryHandling</rdfs:label>
     </owl:Class>
     
 
@@ -625,6 +764,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DiskManagement</rdfs:label>
     </owl:Class>
     
 
@@ -633,6 +774,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DownloadFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">DownloadFile</rdfs:label>
     </owl:Class>
     
 
@@ -641,6 +784,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DynamicLinkLibrary">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
+        <rdfs:comment xml:lang="en">A DynamicLinkLibrary represents a PE file that is a DLL.</rdfs:comment>
+        <rdfs:label xml:lang="en">DynamicLinkLibrary</rdfs:label>
     </owl:Class>
     
 
@@ -649,6 +794,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Encrypt">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Encrypt</rdfs:label>
     </owl:Class>
     
 
@@ -657,6 +804,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateDisks">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateDisks</rdfs:label>
     </owl:Class>
     
 
@@ -665,6 +814,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateLibraries">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LibraryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateLibraries</rdfs:label>
     </owl:Class>
     
 
@@ -673,6 +824,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateNetworkShares">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ResourceSharing"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateNetworkShares</rdfs:label>
     </owl:Class>
     
 
@@ -681,6 +834,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateProcesses">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateProcesses</rdfs:label>
     </owl:Class>
     
 
@@ -689,6 +844,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateRegistryKeySubkeys">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateRegistryKeySubkeys</rdfs:label>
     </owl:Class>
     
 
@@ -697,6 +854,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateRegistryKeyValues">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateRegistryKeyValues</rdfs:label>
     </owl:Class>
     
 
@@ -705,6 +864,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateServices">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateServices</rdfs:label>
     </owl:Class>
     
 
@@ -713,6 +874,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateThreads">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateThreads</rdfs:label>
     </owl:Class>
     
 
@@ -721,6 +884,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateUsers">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateUsers</rdfs:label>
     </owl:Class>
     
 
@@ -729,6 +894,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#EnumerateWindows">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">EnumerateWindows</rdfs:label>
     </owl:Class>
     
 
@@ -737,6 +904,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Executable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
+        <rdfs:comment xml:lang="en">Executable represent the MEM_EXECUTABLE permission flag of PE file sections. It should have a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">Executable</rdfs:label>
     </owl:Class>
     
 
@@ -745,6 +914,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ExecutableFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
+        <rdfs:comment xml:lang="en">An ExecutableFile instance represents a PE file that is an actual executable.</rdfs:comment>
+        <rdfs:label xml:lang="en">ExecutableFile</rdfs:label>
     </owl:Class>
     
 
@@ -753,6 +924,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ExecuteFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ExecuteFile</rdfs:label>
     </owl:Class>
     
 
@@ -761,13 +934,18 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Exports">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Exports</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature">
+        <rdfs:comment xml:lang="en">Subclasses of FileFeature represent features of PE files relevant to malware detection and derived from various properties of samples in the original EMBER-like dataset. Each should have a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">FileFeature</rdfs:label>
+    </owl:Class>
     
 
 
@@ -775,6 +953,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">FileHandling</rdfs:label>
     </owl:Class>
     
 
@@ -783,6 +963,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FindFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">FindFile</rdfs:label>
     </owl:Class>
     
 
@@ -791,6 +973,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FindWindow">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">FindWindow</rdfs:label>
     </owl:Class>
     
 
@@ -799,6 +983,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FlushProcessInstructionCache">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">FlushProcessInstructionCache</rdfs:label>
     </owl:Class>
     
 
@@ -807,6 +993,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FreeLibrary">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LibraryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">FreeLibrary</rdfs:label>
     </owl:Class>
     
 
@@ -815,6 +1003,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FreeProcessVirtualMemory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">FreeProcessVirtualMemory</rdfs:label>
     </owl:Class>
     
 
@@ -823,6 +1013,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GenerateKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GenerateKey</rdfs:label>
     </owl:Class>
     
 
@@ -831,6 +1023,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetDiskAttributes">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetDiskAttributes</rdfs:label>
     </owl:Class>
     
 
@@ -839,6 +1033,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetDiskType">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetDiskType</rdfs:label>
     </owl:Class>
     
 
@@ -847,6 +1043,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetElapsedSystemUpTime">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetElapsedSystemUpTime</rdfs:label>
     </owl:Class>
     
 
@@ -855,6 +1053,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetFileOrDirectoryAttributes">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetFileOrDirectoryAttributes</rdfs:label>
     </owl:Class>
     
 
@@ -863,6 +1063,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetFunctionAddress">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LibraryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetFunctionAddress</rdfs:label>
     </owl:Class>
     
 
@@ -871,6 +1073,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetHostByAddress">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetHostByAddress</rdfs:label>
     </owl:Class>
     
 
@@ -879,6 +1083,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetHostByName">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetHostByName</rdfs:label>
     </owl:Class>
     
 
@@ -887,6 +1093,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetNetbiosName">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetNetbiosName</rdfs:label>
     </owl:Class>
     
 
@@ -895,6 +1103,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetProcessCurrentDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetProcessCurrentDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -903,6 +1113,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetProcessEnvironmentVariable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetProcessEnvironmentVariable</rdfs:label>
     </owl:Class>
     
 
@@ -911,6 +1123,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetProcessStartupinfo">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetProcessStartupinfo</rdfs:label>
     </owl:Class>
     
 
@@ -919,6 +1133,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetSystemGlobalFlags">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetSystemGlobalFlags</rdfs:label>
     </owl:Class>
     
 
@@ -927,6 +1143,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetSystemLocalTime">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetSystemLocalTime</rdfs:label>
     </owl:Class>
     
 
@@ -935,6 +1153,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetSystemTime">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetSystemTime</rdfs:label>
     </owl:Class>
     
 
@@ -943,6 +1163,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetTemporaryFilesDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetTemporaryFilesDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -951,6 +1173,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetThreadContext">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetThreadContext</rdfs:label>
     </owl:Class>
     
 
@@ -959,6 +1183,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetUsername">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetUsername</rdfs:label>
     </owl:Class>
     
 
@@ -967,6 +1193,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetWindowsDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetWindowsDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -975,6 +1203,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GetWindowsSystemDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">GetWindowsSystemDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -983,6 +1213,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#HighEntropy">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">HighEntropy</rdfs:label>
     </owl:Class>
     
 
@@ -991,6 +1223,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ImpersonateProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ImpersonateProcess</rdfs:label>
     </owl:Class>
     
 
@@ -999,6 +1233,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#InitializedDataSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
+        <rdfs:comment xml:lang="en">InitializedDataSection instances represent PE file sections containing initialized data.</rdfs:comment>
+        <rdfs:label xml:lang="en">InitializedDataSection</rdfs:label>
     </owl:Class>
     
 
@@ -1007,6 +1243,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#InterProcessCommunication">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">InterProcessCommunication</rdfs:label>
     </owl:Class>
     
 
@@ -1015,6 +1253,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#KillProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">KillProcess</rdfs:label>
     </owl:Class>
     
 
@@ -1023,6 +1263,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#KillThread">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">KillThread</rdfs:label>
     </owl:Class>
     
 
@@ -1031,6 +1273,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#KillWindow">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">KillWindow</rdfs:label>
     </owl:Class>
     
 
@@ -1039,6 +1283,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LibraryHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">LibraryHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1047,6 +1293,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ListenOnSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ListenOnSocket</rdfs:label>
     </owl:Class>
     
 
@@ -1055,6 +1303,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LoadLibrary">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LibraryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">LoadLibrary</rdfs:label>
     </owl:Class>
     
 
@@ -1063,6 +1313,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LockFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">LockFile</rdfs:label>
     </owl:Class>
     
 
@@ -1071,6 +1323,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LogonAsUser">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">LogonAsUser</rdfs:label>
     </owl:Class>
     
 
@@ -1079,6 +1333,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LowImportsCount">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">LowImportsCount</rdfs:label>
     </owl:Class>
     
 
@@ -1087,6 +1343,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MapFileIntoProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">MapFileIntoProcess</rdfs:label>
     </owl:Class>
     
 
@@ -1095,6 +1353,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ModifyProcessVirtualMemoryProtection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ModifyProcessVirtualMemoryProtection</rdfs:label>
     </owl:Class>
     
 
@@ -1103,6 +1363,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ModifyRegistryKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ModifyRegistryKey</rdfs:label>
     </owl:Class>
     
 
@@ -1111,6 +1373,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ModifyServiceConfiguration">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ModifyServiceConfiguration</rdfs:label>
     </owl:Class>
     
 
@@ -1119,6 +1383,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MonitorDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DirectoryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">MonitorDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -1127,6 +1393,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MonitorRegistryKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">MonitorRegistryKey</rdfs:label>
     </owl:Class>
     
 
@@ -1135,6 +1403,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MountDisk">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">MountDisk</rdfs:label>
     </owl:Class>
     
 
@@ -1143,6 +1413,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MoveFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">MoveFile</rdfs:label>
     </owl:Class>
     
 
@@ -1151,6 +1423,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MultipleExecutableSections">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">MultipleExecutableSections</rdfs:label>
     </owl:Class>
     
 
@@ -1159,6 +1433,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en">Class of networking-related actions.</rdfs:comment>
+        <rdfs:label xml:lang="en">Networking</rdfs:label>
     </owl:Class>
     
 
@@ -1167,6 +1443,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#NonexecutableEntryPoint">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">NonexecutableEntryPoint</rdfs:label>
     </owl:Class>
     
 
@@ -1175,6 +1453,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#NonstandardMZ">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">NonstandardMZ</rdfs:label>
     </owl:Class>
     
 
@@ -1183,6 +1463,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#NonstandardSectionName">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">NonstandardSectionName</rdfs:label>
     </owl:Class>
     
 
@@ -1191,6 +1473,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenCriticalSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenCriticalSection</rdfs:label>
     </owl:Class>
     
 
@@ -1199,6 +1483,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DirectoryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -1207,6 +1493,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenEvent">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenEvent</rdfs:label>
     </owl:Class>
     
 
@@ -1215,6 +1503,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenFileMapping">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenFileMapping</rdfs:label>
     </owl:Class>
     
 
@@ -1223,6 +1513,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenMutex">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenMutex</rdfs:label>
     </owl:Class>
     
 
@@ -1231,6 +1523,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenProcess</rdfs:label>
     </owl:Class>
     
 
@@ -1239,6 +1533,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenRegistryKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenRegistryKey</rdfs:label>
     </owl:Class>
     
 
@@ -1247,6 +1543,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenSemaphore">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenSemaphore</rdfs:label>
     </owl:Class>
     
 
@@ -1255,6 +1553,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OpenService">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OpenService</rdfs:label>
     </owl:Class>
     
 
@@ -1263,13 +1563,18 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#OutputDebugString">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AntiDebugging"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">OutputDebugString</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile"/>
+    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PEFile">
+        <rdfs:comment xml:lang="en">A PEFile instance represents a Portable Executable file sample, which can either be an executable or a shared library, represented by the respective sublasses. A PEFile&apos;s object and data properties describe its structural and behavioral characteristics intresting from the malware-detection point of view, typically extracted from a malware data set such as EMBER or SOREL.</rdfs:comment>
+        <rdfs:label xml:lang="en">PEFile</rdfs:label>
+    </owl:Class>
     
 
 
@@ -1277,6 +1582,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PathStrings">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">PathStrings</rdfs:label>
     </owl:Class>
     
 
@@ -1285,6 +1592,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ProcessHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1293,6 +1602,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#QueueApcInThread">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">QueueApcInThread</rdfs:label>
     </owl:Class>
     
 
@@ -1301,6 +1612,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReadFromFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReadFromFile</rdfs:label>
     </owl:Class>
     
 
@@ -1309,6 +1622,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReadFromProcessMemory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReadFromProcessMemory</rdfs:label>
     </owl:Class>
     
 
@@ -1317,6 +1632,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReadRegistryKeyValue">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReadRegistryKeyValue</rdfs:label>
     </owl:Class>
     
 
@@ -1325,6 +1642,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Readable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
+        <rdfs:comment xml:lang="en">Readable represent the MEM_READABLE permission flag of PE file sections. It has a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">Readable</rdfs:label>
     </owl:Class>
     
 
@@ -1333,6 +1652,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReceiveDataOnSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReceiveDataOnSocket</rdfs:label>
     </owl:Class>
     
 
@@ -1341,6 +1662,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">RegistryHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1349,6 +1672,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryStrings">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">RegistryStrings</rdfs:label>
     </owl:Class>
     
 
@@ -1357,6 +1682,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReleaseCriticalSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReleaseCriticalSection</rdfs:label>
     </owl:Class>
     
 
@@ -1365,6 +1692,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReleaseMutex">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReleaseMutex</rdfs:label>
     </owl:Class>
     
 
@@ -1373,6 +1702,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ReleaseSemaphore">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ReleaseSemaphore</rdfs:label>
     </owl:Class>
     
 
@@ -1381,6 +1712,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Relocations">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Relocations</rdfs:label>
     </owl:Class>
     
 
@@ -1389,6 +1722,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RemoveUserFromGroup">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">RemoveUserFromGroup</rdfs:label>
     </owl:Class>
     
 
@@ -1397,6 +1732,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ResetEvent">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ResetEvent</rdfs:label>
     </owl:Class>
     
 
@@ -1405,6 +1742,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ResourceSharing">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ResourceSharing</rdfs:label>
     </owl:Class>
     
 
@@ -1413,6 +1752,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Resources">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Resources</rdfs:label>
     </owl:Class>
     
 
@@ -1421,25 +1762,36 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RevertThreadToSelf">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">RevertThreadToSelf</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
+    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section">
+        <rdfs:comment xml:lang="en">Instances of Section represent sections of PEFile samples. The individual representing a section should be classified according to the type of data the section contains into one of Section&apos;s subclasses.</rdfs:comment>
+        <rdfs:label xml:lang="en">Section</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
+    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature">
+        <rdfs:comment xml:lang="en">Subclasses of SectionFeature represent features of PE file sections relevant to malware detection and derived from various properties of sections in the original EMBER-like dataset. Each should have a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">SectionFeature</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
+    <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag">
+        <rdfs:comment xml:lang="en">Subclasses of SectionFlag represent permission flags of PE file sections. Each should have a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">SectionFlag</rdfs:label>
+    </owl:Class>
     
 
 
@@ -1447,6 +1799,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendDataOnSocket">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SendDataOnSocket</rdfs:label>
     </owl:Class>
     
 
@@ -1455,6 +1809,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendDnsQuery">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SendDnsQuery</rdfs:label>
     </owl:Class>
     
 
@@ -1463,6 +1819,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendFtpCommand">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SendFtpCommand</rdfs:label>
     </owl:Class>
     
 
@@ -1471,6 +1829,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendHttpConnectRequest">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SendHttpConnectRequest</rdfs:label>
     </owl:Class>
     
 
@@ -1479,6 +1839,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendHttpRequest">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SendHttpRequest</rdfs:label>
     </owl:Class>
     
 
@@ -1487,6 +1849,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendIcmpRequest">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SendIcmpRequest</rdfs:label>
     </owl:Class>
     
 
@@ -1495,6 +1859,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ServiceHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1503,6 +1869,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SetFileOrDirectoryAttributes">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SetFileOrDirectoryAttributes</rdfs:label>
     </owl:Class>
     
 
@@ -1511,6 +1879,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SetNetbiosName">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SetNetbiosName</rdfs:label>
     </owl:Class>
     
 
@@ -1519,6 +1889,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SetProcessCurrentDirectory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SetProcessCurrentDirectory</rdfs:label>
     </owl:Class>
     
 
@@ -1527,6 +1899,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SetProcessEnvironmentVariable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SetProcessEnvironmentVariable</rdfs:label>
     </owl:Class>
     
 
@@ -1535,6 +1909,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SetSystemTime">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SetSystemTime</rdfs:label>
     </owl:Class>
     
 
@@ -1543,6 +1919,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SetThreadContext">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SetThreadContext</rdfs:label>
     </owl:Class>
     
 
@@ -1551,6 +1929,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Shareable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
+        <rdfs:comment xml:lang="en">Shareable represents the MEM_SHAREABLE permission flag of PE file sections. It should have a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">Shareable</rdfs:label>
     </owl:Class>
     
 
@@ -1559,6 +1939,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ShowWindow">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ShowWindow</rdfs:label>
     </owl:Class>
     
 
@@ -1567,6 +1949,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ShutdownSystem">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ShutdownSystem</rdfs:label>
     </owl:Class>
     
 
@@ -1575,6 +1959,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Signature">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Signature</rdfs:label>
     </owl:Class>
     
 
@@ -1583,6 +1969,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SleepProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SleepProcess</rdfs:label>
     </owl:Class>
     
 
@@ -1591,6 +1979,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#StartService">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">StartService</rdfs:label>
     </owl:Class>
     
 
@@ -1599,6 +1989,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#StopService">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ServiceHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">StopService</rdfs:label>
     </owl:Class>
     
 
@@ -1607,6 +1999,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Symbols">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">Symbols</rdfs:label>
     </owl:Class>
     
 
@@ -1615,6 +2009,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SynchronizationPrimitivesHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SynchronizationPrimitivesHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1623,6 +2019,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">SystemManipulation</rdfs:label>
     </owl:Class>
     
 
@@ -1631,6 +2029,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#TLS">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">TLS</rdfs:label>
     </owl:Class>
     
 
@@ -1639,6 +2039,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ThreadHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">ThreadHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1647,6 +2049,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#URLStrings">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">URLStrings</rdfs:label>
     </owl:Class>
     
 
@@ -1655,6 +2059,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#UninitializedDataSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Section"/>
+        <rdfs:comment xml:lang="en">UninitializedDataSection instances represent PE file sections containing uninitialized data.</rdfs:comment>
+        <rdfs:label xml:lang="en">UninitializedDataSection</rdfs:label>
     </owl:Class>
     
 
@@ -1663,6 +2069,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#UnloadDriver">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SystemManipulation"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">UnloadDriver</rdfs:label>
     </owl:Class>
     
 
@@ -1671,6 +2079,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#UnlockFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">UnlockFile</rdfs:label>
     </owl:Class>
     
 
@@ -1679,6 +2089,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#UnmapFileFromProcess">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">UnmapFileFromProcess</rdfs:label>
     </owl:Class>
     
 
@@ -1687,6 +2099,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#UnmountDisk">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">UnmountDisk</rdfs:label>
     </owl:Class>
     
 
@@ -1695,6 +2109,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WindowHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">WindowHandling</rdfs:label>
     </owl:Class>
     
 
@@ -1703,6 +2119,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Writable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
+        <rdfs:comment xml:lang="en">Writable represent the MEM_WRITABLE permission flag of PE file sections. It should have a single prototypical instance.</rdfs:comment>
+        <rdfs:label xml:lang="en">Writable</rdfs:label>
     </owl:Class>
     
 
@@ -1711,6 +2129,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WriteExecuteSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">WriteExecuteSection</rdfs:label>
     </owl:Class>
     
 
@@ -1719,6 +2139,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WriteToFile">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">WriteToFile</rdfs:label>
     </owl:Class>
     
 
@@ -1727,6 +2149,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WriteToProcessMemory">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#ProcessHandling"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">WriteToProcessMemory</rdfs:label>
     </owl:Class>
 </rdf:RDF>
 

--- a/ember_ontology.owl
+++ b/ember_ontology.owl
@@ -5,8 +5,31 @@
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:malware-ontology="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#malware-ontology:">
     <owl:Ontology rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#malware-ontology:derived_as -->
+
+    <owl:AnnotationProperty rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#malware-ontology:derived_as">
+        <rdfs:comment xml:lang="en">The derived_as annotation property indicates that the annotated file or section feature is derived, i.e., the class of PE files/sections possessing this property can be defined by a suitable OWL 2 expression. The value of this property is a string rendering this expression in the Manchester syntax.
+
+This annotation property is intended to help applications filter out features that can be considered redundant if the learning tool can learn a class description equivalent to the definition of the feature.</rdfs:comment>
+        <rdfs:label xml:lang="en">derived_as</rdfs:label>
+    </owl:AnnotationProperty>
     
 
 
@@ -225,7 +248,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AccessManagement">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions managing users on the system (adding new user, enumerating existing users, etc.)</rdfs:comment>
         <rdfs:label xml:lang="en">AccessManagement</rdfs:label>
     </owl:Class>
     
@@ -294,7 +317,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#AntiDebugging">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions used in debugger detection techniques.</rdfs:comment>
         <rdfs:label xml:lang="en">AntiDebugging</rdfs:label>
     </owl:Class>
     
@@ -314,7 +337,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#CLR">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The CLR feature indicates that the respective PE file contains a Common Language Runtime data directory (used in .NET binaries).</rdfs:comment>
         <rdfs:label xml:lang="en">CLR</rdfs:label>
     </owl:Class>
     
@@ -644,7 +667,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions of using cryptographic facilities (encrypting/decrypting files, generating keys, etc.).</rdfs:comment>
         <rdfs:label xml:lang="en">Cryptography</rdfs:label>
     </owl:Class>
     
@@ -654,7 +677,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Debug">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The Debug feature indicates that the respective PE file contains a debug section.</rdfs:comment>
         <rdfs:label xml:lang="en">Debug</rdfs:label>
     </owl:Class>
     
@@ -664,7 +687,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Decrypt">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The action of file decryption. (Not in the MAEC malware actions vocabulary.)</rdfs:comment>
         <rdfs:label xml:lang="en">Decrypt</rdfs:label>
     </owl:Class>
     
@@ -754,7 +777,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DirectoryHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions of manipulating directories (creation, deletion, etc.).</rdfs:comment>
         <rdfs:label xml:lang="en">DirectoryHandling</rdfs:label>
     </owl:Class>
     
@@ -764,7 +787,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#DiskManagement">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of disk management actions (mounting/unmounting disks, enumerating existing disks, etc.).</rdfs:comment>
         <rdfs:label xml:lang="en">DiskManagement</rdfs:label>
     </owl:Class>
     
@@ -794,7 +817,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Encrypt">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The action of file encryption. (Not in the MAEC malware actions vocabulary.)</rdfs:comment>
         <rdfs:label xml:lang="en">Encrypt</rdfs:label>
     </owl:Class>
     
@@ -904,7 +927,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Executable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
-        <rdfs:comment xml:lang="en">Executable represent the MEM_EXECUTABLE permission flag of PE file sections. It should have a single prototypical instance.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Executable represent the MEM_EXECUTABLE permission flag of PE file sections.</rdfs:comment>
         <rdfs:label xml:lang="en">Executable</rdfs:label>
     </owl:Class>
     
@@ -934,7 +957,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Exports">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>exports_count some xsd:integer[&gt; 0]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The Exports feature indicates that the respective PE file exports some functions (mostly true for DLLs).</rdfs:comment>
         <rdfs:label xml:lang="en">Exports</rdfs:label>
     </owl:Class>
     
@@ -953,7 +977,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions of manipulating with files (creation, deletion, etc.).</rdfs:comment>
         <rdfs:label xml:lang="en">FileHandling</rdfs:label>
     </owl:Class>
     
@@ -1013,7 +1037,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#GenerateKey">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Cryptography"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The action of cryptographic key generation. (Not in the MAEC malware actions vocabulary.)</rdfs:comment>
         <rdfs:label xml:lang="en">GenerateKey</rdfs:label>
     </owl:Class>
     
@@ -1213,7 +1237,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#HighEntropy">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>section_entropy some xsd:double[&gt; &quot;7.0&quot;^^xsd:double]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The value of section&apos;s entropy is larger than the threshold value (7.0 by default).</rdfs:comment>
         <rdfs:label xml:lang="en">HighEntropy</rdfs:label>
     </owl:Class>
     
@@ -1243,7 +1268,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#InterProcessCommunication">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions of communication between processes (using, e.g., named pipes).</rdfs:comment>
         <rdfs:label xml:lang="en">InterProcessCommunication</rdfs:label>
     </owl:Class>
     
@@ -1283,7 +1308,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LibraryHandling">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of actions of loading libraries into running processes.</rdfs:comment>
         <rdfs:label xml:lang="en">LibraryHandling</rdfs:label>
     </owl:Class>
     
@@ -1333,7 +1358,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#LowImportsCount">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>imports_count some xsd:integer[&lt; 10]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The LowImportsCount feature indicates that the respective PE file&apos;s number of imported functions is smaller than the threshold value (10 by default).</rdfs:comment>
         <rdfs:label xml:lang="en">LowImportsCount</rdfs:label>
     </owl:Class>
     
@@ -1423,7 +1449,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#MultipleExecutableSections">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>has_section min 2 (has_section_flag some Executable)</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The MultipleExecutableSections feature indicates that the respective PE file has multiple sections with the executable flag.</rdfs:comment>
         <rdfs:label xml:lang="en">MultipleExecutableSections</rdfs:label>
     </owl:Class>
     
@@ -1433,7 +1460,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Action"/>
-        <rdfs:comment xml:lang="en">Class of networking-related actions.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The class of various networking-related actions (e.g., connecting to a socket, sending various types of requests).</rdfs:comment>
         <rdfs:label xml:lang="en">Networking</rdfs:label>
     </owl:Class>
     
@@ -1443,7 +1470,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#NonexecutableEntryPoint">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The NonexecutableEntryPoint feature indicates that the respective PE file&apos;s entry point is not in an executable section.</rdfs:comment>
         <rdfs:label xml:lang="en">NonexecutableEntryPoint</rdfs:label>
     </owl:Class>
     
@@ -1453,7 +1480,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#NonstandardMZ">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>mz_count some xsd:integer[&gt; 1 , &lt; 1]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The NonstandardMZ feature indicates that the PE file contains more than one MZ header.</rdfs:comment>
         <rdfs:label xml:lang="en">NonstandardMZ</rdfs:label>
     </owl:Class>
     
@@ -1463,7 +1491,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#NonstandardSectionName">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>section_name some  not ({&quot;.adata&quot; , &quot;.bss&quot; , &quot;.code&quot; , &quot;.crt&quot; , &quot;.data&quot; , &quot;.debug&quot; , &quot;.didat&quot; , &quot;.didata&quot; , &quot;.edata&quot; , &quot;.gfids&quot; , &quot;.idata&quot; , &quot;.ndata&quot; , &quot;.pdata&quot; , &quot;.rdata&quot; , &quot;.reloc&quot; , &quot;.rodata&quot; , &quot;.rsrc&quot; , &quot;.sbss&quot; , &quot;.sdata&quot; , &quot;.shared&quot; , &quot;.sxdata&quot; , &quot;.text&quot; , &quot;.textbss&quot; , &quot;.tls&quot; , &quot;.udata&quot; , &quot;.xdata&quot; , &quot;bss&quot; , &quot;code&quot; , &quot;data&quot; , &quot;init&quot; , &quot;ndata&quot; , &quot;rdata&quot; , &quot;shared&quot; , &quot;tls&quot;})</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">Section&apos;s name is not in the list of standard section names.</rdfs:comment>
         <rdfs:label xml:lang="en">NonstandardSectionName</rdfs:label>
     </owl:Class>
     
@@ -1582,7 +1611,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#PathStrings">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>paths_strings_count some xsd:integer[&gt; 0]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The PathStrings feature indicates that the respective PE file contains strings defining paths.</rdfs:comment>
         <rdfs:label xml:lang="en">PathStrings</rdfs:label>
     </owl:Class>
     
@@ -1642,7 +1672,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Readable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
-        <rdfs:comment xml:lang="en">Readable represent the MEM_READABLE permission flag of PE file sections. It has a single prototypical instance.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Readable represent the MEM_READABLE permission flag of PE file sections.</rdfs:comment>
         <rdfs:label xml:lang="en">Readable</rdfs:label>
     </owl:Class>
     
@@ -1672,7 +1702,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#RegistryStrings">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>registry_strings_count some xsd:integer[&gt; 0]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The RegistryStrings feature indicates that the respective PE file contains strings defining registry keys.</rdfs:comment>
         <rdfs:label xml:lang="en">RegistryStrings</rdfs:label>
     </owl:Class>
     
@@ -1712,7 +1743,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Relocations">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The Relocations feature indicates that the respective PE file contains a relocation section.</rdfs:comment>
         <rdfs:label xml:lang="en">Relocations</rdfs:label>
     </owl:Class>
     
@@ -1752,7 +1783,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Resources">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The Relocations feature indicates that the respective PE file contains resources (fonts, images, etc.).</rdfs:comment>
         <rdfs:label xml:lang="en">Resources</rdfs:label>
     </owl:Class>
     
@@ -1780,7 +1811,7 @@
     <!-- http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature -->
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature">
-        <rdfs:comment xml:lang="en">Subclasses of SectionFeature represent features of PE file sections relevant to malware detection and derived from various properties of sections in the original EMBER-like dataset. Each should have a single prototypical instance.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Subclasses of SectionFeature represent features of PE file sections relevant to malware detection and derived from various properties of sections in the original EMBER/SoReL dataset. Each should have a single prototypical instance.</rdfs:comment>
         <rdfs:label xml:lang="en">SectionFeature</rdfs:label>
     </owl:Class>
     
@@ -1839,7 +1870,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SendHttpRequest">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Networking"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The action of sending an HTTP client request to a server. (Not in the MAEC malware actions vocabulary.)</rdfs:comment>
         <rdfs:label xml:lang="en">SendHttpRequest</rdfs:label>
     </owl:Class>
     
@@ -1929,7 +1960,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Shareable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
-        <rdfs:comment xml:lang="en">Shareable represents the MEM_SHAREABLE permission flag of PE file sections. It should have a single prototypical instance.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Shareable represents the MEM_SHAREABLE permission flag of PE file sections.</rdfs:comment>
         <rdfs:label xml:lang="en">Shareable</rdfs:label>
     </owl:Class>
     
@@ -1959,7 +1990,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Signature">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The Signature feature indicates that the respective PE file is digitally signed.</rdfs:comment>
         <rdfs:label xml:lang="en">Signature</rdfs:label>
     </owl:Class>
     
@@ -1999,7 +2030,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Symbols">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>symbols_count some xsd:integer[&gt; 0]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The Debug feature indicates that the respective PE file has COFF debug symbols (deprecated in executables).</rdfs:comment>
         <rdfs:label xml:lang="en">Symbols</rdfs:label>
     </owl:Class>
     
@@ -2029,7 +2061,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#TLS">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:comment xml:lang="en">The Debug feature indicates that the respective PE file includes a Thread Location Storage section (possibly a secret entry point).</rdfs:comment>
         <rdfs:label xml:lang="en">TLS</rdfs:label>
     </owl:Class>
     
@@ -2049,7 +2081,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#URLStrings">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#FileFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>urls_strings_count some xsd:integer[&gt; 0]</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">The RegistryStrings feature indicates that the respective PE file contains strings defining URLs.</rdfs:comment>
         <rdfs:label xml:lang="en">URLStrings</rdfs:label>
     </owl:Class>
     
@@ -2119,7 +2152,7 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Writable">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFlag"/>
-        <rdfs:comment xml:lang="en">Writable represent the MEM_WRITABLE permission flag of PE file sections. It should have a single prototypical instance.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Writable represent the MEM_WRITABLE permission flag of PE file sections.</rdfs:comment>
         <rdfs:label xml:lang="en">Writable</rdfs:label>
     </owl:Class>
     
@@ -2129,7 +2162,8 @@
 
     <owl:Class rdf:about="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#WriteExecuteSection">
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#SectionFeature"/>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <malware-ontology:derived_as>(has_section_flag some Executable) and (has_section_flag some Writable)</malware-ontology:derived_as>
+        <rdfs:comment xml:lang="en">Section has write and execute permissions.</rdfs:comment>
         <rdfs:label xml:lang="en">WriteExecuteSection</rdfs:label>
     </owl:Class>
     
@@ -2152,6 +2186,395 @@
         <rdfs:comment xml:lang="en"></rdfs:comment>
         <rdfs:label xml:lang="en">WriteToProcessMemory</rdfs:label>
     </owl:Class>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#section_name"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:datatypeComplementOf>
+                            <rdfs:Datatype>
+                                <owl:oneOf>
+                                    <rdf:Description>
+                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                        <rdf:first>.adata</rdf:first>
+                                        <rdf:rest>
+                                            <rdf:Description>
+                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                <rdf:first>.bss</rdf:first>
+                                                <rdf:rest>
+                                                    <rdf:Description>
+                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                        <rdf:first>.code</rdf:first>
+                                                        <rdf:rest>
+                                                            <rdf:Description>
+                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                <rdf:first>.crt</rdf:first>
+                                                                <rdf:rest>
+                                                                    <rdf:Description>
+                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                        <rdf:first>.data</rdf:first>
+                                                                        <rdf:rest>
+                                                                            <rdf:Description>
+                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                <rdf:first>.debug</rdf:first>
+                                                                                <rdf:rest>
+                                                                                    <rdf:Description>
+                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                        <rdf:first>.didat</rdf:first>
+                                                                                        <rdf:rest>
+                                                                                            <rdf:Description>
+                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                <rdf:first>.didata</rdf:first>
+                                                                                                <rdf:rest>
+                                                                                                    <rdf:Description>
+                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                        <rdf:first>.edata</rdf:first>
+                                                                                                        <rdf:rest>
+                                                                                                            <rdf:Description>
+                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                <rdf:first>.gfids</rdf:first>
+                                                                                                                <rdf:rest>
+                                                                                                                    <rdf:Description>
+                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                        <rdf:first>.idata</rdf:first>
+                                                                                                                        <rdf:rest>
+                                                                                                                            <rdf:Description>
+                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                <rdf:first>.ndata</rdf:first>
+                                                                                                                                <rdf:rest>
+                                                                                                                                    <rdf:Description>
+                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                        <rdf:first>.pdata</rdf:first>
+                                                                                                                                        <rdf:rest>
+                                                                                                                                            <rdf:Description>
+                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                <rdf:first>.rdata</rdf:first>
+                                                                                                                                                <rdf:rest>
+                                                                                                                                                    <rdf:Description>
+                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                        <rdf:first>.reloc</rdf:first>
+                                                                                                                                                        <rdf:rest>
+                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                <rdf:first>.rodata</rdf:first>
+                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                        <rdf:first>.rsrc</rdf:first>
+                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                <rdf:first>.sbss</rdf:first>
+                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                        <rdf:first>.sdata</rdf:first>
+                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                <rdf:first>.shared</rdf:first>
+                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                        <rdf:first>.sxdata</rdf:first>
+                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                <rdf:first>.text</rdf:first>
+                                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                        <rdf:first>.textbss</rdf:first>
+                                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                <rdf:first>.tls</rdf:first>
+                                                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                        <rdf:first>.udata</rdf:first>
+                                                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                <rdf:first>.xdata</rdf:first>
+                                                                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                        <rdf:first>bss</rdf:first>
+                                                                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                <rdf:first>code</rdf:first>
+                                                                                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                        <rdf:first>data</rdf:first>
+                                                                                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                                <rdf:first>init</rdf:first>
+                                                                                                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                                        <rdf:first>ndata</rdf:first>
+                                                                                                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                                                <rdf:first>rdata</rdf:first>
+                                                                                                                                                                                                                                                                                                <rdf:rest>
+                                                                                                                                                                                                                                                                                                    <rdf:Description>
+                                                                                                                                                                                                                                                                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                                                        <rdf:first>shared</rdf:first>
+                                                                                                                                                                                                                                                                                                        <rdf:rest>
+                                                                                                                                                                                                                                                                                                            <rdf:Description>
+                                                                                                                                                                                                                                                                                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                                                                                                                                                                                                                                                                                <rdf:first>tls</rdf:first>
+                                                                                                                                                                                                                                                                                                                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+                                                                                                                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                                </rdf:rest>
+                                                                                                                                                                            </rdf:Description>
+                                                                                                                                                                        </rdf:rest>
+                                                                                                                                                                    </rdf:Description>
+                                                                                                                                                                </rdf:rest>
+                                                                                                                                                            </rdf:Description>
+                                                                                                                                                        </rdf:rest>
+                                                                                                                                                    </rdf:Description>
+                                                                                                                                                </rdf:rest>
+                                                                                                                                            </rdf:Description>
+                                                                                                                                        </rdf:rest>
+                                                                                                                                    </rdf:Description>
+                                                                                                                                </rdf:rest>
+                                                                                                                            </rdf:Description>
+                                                                                                                        </rdf:rest>
+                                                                                                                    </rdf:Description>
+                                                                                                                </rdf:rest>
+                                                                                                            </rdf:Description>
+                                                                                                        </rdf:rest>
+                                                                                                    </rdf:Description>
+                                                                                                </rdf:rest>
+                                                                                            </rdf:Description>
+                                                                                        </rdf:rest>
+                                                                                    </rdf:Description>
+                                                                                </rdf:rest>
+                                                                            </rdf:Description>
+                                                                        </rdf:rest>
+                                                                    </rdf:Description>
+                                                                </rdf:rest>
+                                                            </rdf:Description>
+                                                        </rdf:rest>
+                                                    </rdf:Description>
+                                                </rdf:rest>
+                                            </rdf:Description>
+                                        </rdf:rest>
+                                    </rdf:Description>
+                                </owl:oneOf>
+                            </rdfs:Datatype>
+                        </owl:datatypeComplementOf>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#has_section_flag"/>
+                        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Executable"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#has_section_flag"/>
+                        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Writable"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#paths_strings_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</xsd:minExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#imports_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:maxExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</xsd:maxExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#section_entropy"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#double">7.0</xsd:minExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#urls_strings_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</xsd:minExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#exports_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</xsd:minExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#symbols_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</xsd:minExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#has_section"/>
+                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+                <owl:onClass>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#has_section_flag"/>
+                        <owl:someValuesFrom rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#Executable"/>
+                    </owl:Restriction>
+                </owl:onClass>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#registry_strings_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</xsd:minExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/peter/ontologies/2020/malware-ontology#mz_count"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+                        <owl:withRestrictions rdf:parseType="Collection">
+                            <rdf:Description>
+                                <xsd:minExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</xsd:minExclusive>
+                            </rdf:Description>
+                            <rdf:Description>
+                                <xsd:maxExclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</xsd:maxExclusive>
+                            </rdf:Description>
+                        </owl:withRestrictions>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdf:type>
+    </rdf:Description>
 </rdf:RDF>
 
 


### PR DESCRIPTION
Annotations should be added to ontology entities so that it is self-documenting and documentation can be generated by specgen or OWLDoc.

- [x] Classes
    - [x] Top-level (Action, PEFile, FileFeature, Section, SectionFlag, SectionFeature)
    - [x] File features
    - [x] Section flags
    - [x] Section features
    - [x] Action mid-level classes
    - [x] Actions
- [ ] Data properties
- [ ] Object properties
- [ ] The ontology itself
- [x] Special annotation property for derived features